### PR TITLE
Switch from rfc3339 to iso8601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,38 @@
-# 0.2.4
+# Changelog
+
+## 0.3.0
+
+* Forked from <https://github.com/softprops/goji>
+* Added several open pull request from <https://github.com/softprops/goji>
+* Added additional contributions from forks on github.
+* Renamed the library from goji to gouqi
+
+## 0.2.4
 
 * added boards issue search api interface [#30](https://github.com/softprops/goji/pull/30)
 * added `Issue.permalink` convenience method [#31](https://github.com/softprops/goji/pull/31)
 * fixed issue with boards iterator [#32](https://github.com/softprops/goji/pull/32)
 * fix naming issue with `issue.resolutiondate` field [#34](https://github.com/softprops/goji/pull/34/files)
 
-# 0.2.3
+## 0.2.3
 
 * fix breaking changes with agile api paths
 
-# 0.2.2
+## 0.2.2
 
 * added sprints interfaces [#24](https://github.com/softprops/goji/pull/24)
 * added boarders interfaces [#21](https://github.com/softprops/goji/pull/21)
 * added agile api [#20](https://github.com/softprops/goji/pull/20)
 
-# 0.2.1
+## 0.2.1
 
 * updated issue and attachment interfaces
 
-# 0.2.0
+## 0.2.0
 
 * replace hyper client with reqwest
 
-# 0.1.1
+## 0.1.1
 
 * expanded search interface with and `iter` method that implements an `Iterator` over `Issues`
 * changed `SearchListOptionsBuilder#max` to `max_results` be more consistent with the underlying api
@@ -31,6 +40,6 @@
 * replaced usage of `u32` with `u64` for a more consistent interface
 * renamed `TransitionTrigger` to `TransitionTriggerOptions` for a more consistent api
 
-# 0.1.0
+## 0.1.0
 
 * initial release

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > a rust interface for [jira](https://www.atlassian.com/software/jira)
 
-Forked from goji https://softprops.github.io/goji
+Forked from goji <https://softprops.github.io/goji>
 
 ## install
 

--- a/src/sprints.rs
+++ b/src/sprints.rs
@@ -12,21 +12,21 @@ pub struct Sprints {
     jira: Jira,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Sprint {
     pub id: u64,
     #[serde(rename = "self")]
     pub self_link: String,
     pub name: String,
     pub state: Option<String>,
-    #[serde(default, rename = "startDate", with = "time::serde::rfc3339::option")]
+    #[serde(default, rename = "startDate", with = "time::serde::iso8601::option")]
     pub start_date: Option<OffsetDateTime>,
-    #[serde(default, rename = "endDate", with = "time::serde::rfc3339::option")]
+    #[serde(default, rename = "endDate", with = "time::serde::iso8601::option")]
     pub end_date: Option<OffsetDateTime>,
     #[serde(
         default,
         rename = "completeDate",
-        with = "time::serde::rfc3339::option"
+        with = "time::serde::iso8601::option"
     )]
     pub complete_date: Option<OffsetDateTime>,
     #[serde(rename = "originBoardId")]

--- a/tests/rep_test.rs
+++ b/tests/rep_test.rs
@@ -13,7 +13,9 @@ fn issue_getters() {
         "id": "1234",
         "key": "MYPROJ-1234",
         "fields": {
-            "resolutiondate": "2018-07-11T16:56:12.000+0000"
+            "resolutiondate": "2018-07-11T16:56:12.000+0000",
+            "created": "2018-07-11T10:56:12.000Z",
+            "updated": "2018-07-11T12:56:12.000+00:00"
         }
     }"#;
 
@@ -23,7 +25,11 @@ fn issue_getters() {
 
     let expected_permalink = format!("{}/browse/{}", JIRA_HOST, issue.key);
     let expected_resolution_date = Some(datetime!(2018-07-11 16:56:12.000 +00:00));
+    let expected_created_date = Some(datetime!(2018-07-11 10:56:12.000 +00:00));
+    let expected_updated_date = Some(datetime!(2018-07-11 12:56:12.000 +00:00));
 
     assert_eq!(issue.permalink(&jira), expected_permalink);
     assert_eq!(issue.resolution_date(), expected_resolution_date);
+    assert_eq!(issue.created(), expected_created_date);
+    assert_eq!(issue.updated(), expected_updated_date);
 }


### PR DESCRIPTION
The time conversion was only partial working
for times which have been the same in
rfc3339 and iso8601. With the update of the
time crate to support iso8601, remove the
workaround.

#17