### PR TITLE
feat(examples): setup examples to follow RUST_LOG for tracing level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2021"
 
 [dev-dependencies]
-tracing-subscriber = "0.3.11"
+tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 skeptic = "0.13"
 
 [build-dependencies]
@@ -20,9 +20,12 @@ skeptic = "0.13"
 
 [dependencies]
 tracing = "0.1.35"
-reqwest = { version = "0.11.11", default_features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11.11", default_features = false, features = [
+    "blocking",
+    "rustls-tls",
+] }
 serde = "1.0.137"
 serde_derive = "1.0.137"
 serde_json = "1.0.82"
 url = "2.2.2"
-time = { version="0.3.11", features =['serde-well-known', 'macros']}
+time = { version = "0.3.11", features = ['serde-well-known', 'macros'] }

--- a/examples/search.rs
+++ b/examples/search.rs
@@ -1,15 +1,18 @@
-use tracing::{error, Level};
-
 extern crate gouqi;
 
 use gouqi::{Credentials, Jira};
 use std::env;
+use tracing::error;
 
 fn main() {
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(Level::TRACE)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
+    // Initialize tracing global tracing subscriber
+    use tracing_subscriber::prelude::*;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        // Use RUST_LOG environment variable to set the tracing level
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        // Sets this to be the default, global collector for this application.
+        .init();
 
     if let (Ok(host), Ok(user), Ok(password)) = (
         env::var("JIRA_HOST"),

--- a/examples/sprint.rs
+++ b/examples/sprint.rs
@@ -1,15 +1,18 @@
-use tracing::{error, Level};
-
 extern crate gouqi;
 
 use gouqi::{Credentials, Jira, Sprints};
 use std::env;
+use tracing::error;
 
 fn main() {
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(Level::TRACE)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
+    // Initialize tracing global tracing subscriber
+    use tracing_subscriber::prelude::*;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        // Use RUST_LOG environment variable to set the tracing level
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        // Sets this to be the default, global collector for this application.
+        .init();
 
     if let (Ok(host), Ok(user), Ok(password)) = (
         env::var("JIRA_HOST"),

--- a/examples/transitions.rs
+++ b/examples/transitions.rs
@@ -2,16 +2,16 @@ extern crate gouqi;
 
 use gouqi::{Credentials, Jira, TransitionTriggerOptions};
 use std::env;
-use tracing::Level;
 
 fn main() {
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
-        // will be written to stdout.
-        .with_max_level(Level::TRACE)
-        // builds the subscriber.
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
+    // Initialize tracing global tracing subscriber
+    use tracing_subscriber::prelude::*;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        // Use RUST_LOG environment variable to set the tracing level
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        // Sets this to be the default, global collector for this application.
+        .init();
 
     if let (Ok(host), Ok(user), Ok(pass), Ok(key)) = (
         env::var("JIRA_HOST"),


### PR DESCRIPTION
Simple modification so that examples are not as verbose by default
