### PR TITLE
fix: Made User field optional in History to allow deserialization when missing

### DIFF
--- a/src/boards.rs
+++ b/src/boards.rs
@@ -11,7 +11,7 @@ pub struct Boards {
     jira: Jira,
 }
 
-#[derive(Deserialize, Debug, Clone, Copy)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Board {
     #[serde(rename = "self")]
     pub self_link: String,

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -325,7 +325,7 @@ pub struct User {
     #[serde(rename = "emailAddress")]
     pub email_address: Option<String>,
     pub key: Option<String>,
-    pub name: String,
+    pub name: Option<String>,
     #[serde(rename = "self")]
     pub self_link: String,
     #[serde(rename = "timeZone")]


### PR DESCRIPTION
In our Jira instance, deserialization of the Changelog field was failing due to missing users (potentially deactivated accounts). Made that field optional to allow deserialization in that case.