### PR TITLE
Fix Serde property rename in Priority deserializer

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -345,6 +345,7 @@ pub struct Status {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Priority {
+    #[serde(rename = "iconUrl")]
     pub icon_url: String,
     pub id: String,
     pub name: String,


### PR DESCRIPTION
The `Priority` structure used by the `Issue` structure to deserialize the priority object was missing a property rename, causing the deserialization to always fail. Added the camel case to snake case field rename.