### PR TITLE
Public http request methods: get, put, post, delete

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ impl Jira {
     }
 
     #[tracing::instrument]
-    fn delete<D>(&self, api_name: &str, endpoint: &str) -> Result<D>
+    pub fn delete<D>(&self, api_name: &str, endpoint: &str) -> Result<D>
     where
         D: DeserializeOwned,
     {
@@ -179,14 +179,14 @@ impl Jira {
     }
 
     #[tracing::instrument]
-    fn get<D>(&self, api_name: &str, endpoint: &str) -> Result<D>
+    pub fn get<D>(&self, api_name: &str, endpoint: &str) -> Result<D>
     where
         D: DeserializeOwned,
     {
         self.request::<D>(Method::GET, api_name, endpoint, None)
     }
 
-    fn post<D, S>(&self, api_name: &str, endpoint: &str, body: S) -> Result<D>
+    pub fn post<D, S>(&self, api_name: &str, endpoint: &str, body: S) -> Result<D>
     where
         D: DeserializeOwned,
         S: Serialize,
@@ -196,7 +196,7 @@ impl Jira {
         self.request::<D>(Method::POST, api_name, endpoint, Some(data.into_bytes()))
     }
 
-    fn put<D, S>(&self, api_name: &str, endpoint: &str, body: S) -> Result<D>
+    pub fn put<D, S>(&self, api_name: &str, endpoint: &str, body: S) -> Result<D>
     where
         D: DeserializeOwned,
         S: Serialize,


### PR DESCRIPTION
Not all end points are implemented in this library and as new ones are added in Jira, clients may lag behind.
As such, a helpful stop gap is to make the request methods available, i.e. `get`, `put`, `delete`, `post`.
These automatically take care of managing credentials and provide the right API for serialization and deserialization.
One example of how to approach this is [octocrab](https://github.com/XAMPPRocky/octocrab#http-api).

This implementation takes the simplest approach, just make the public. Another approach, but a bit more work would be to namespace them. For example, add a `.api` object to `Jira` or similar to not pollute the Jira namespace too much. Open to other ideas too.
