### PR TITLE
Newer api add comment indirection.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gouqi"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["softprops <d.tangren@gmail.com>", "avrabe <ralf_beier@me.com>"]
 description = "Rust interface for Jira"
 documentation = "https://docs.rs/gouqi"
@@ -12,21 +12,21 @@ readme = "README.md"
 edition = "2021"
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 skeptic = "0.13"
-mockito = "1.1.0"
+mockito = "1.4.0"
 
 [build-dependencies]
 skeptic = "0.13"
 
 [dependencies]
 tracing = "0.1.37"
-reqwest = { version = "0.12.0", default_features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
     "blocking",
     "rustls-tls",
 ] }
-serde = "1.0.137"
-serde_derive = "1.0.137"
-serde_json = "1.0.82"
-url = "2.3.1"
-time = { version = "0.3.17", features = ['serde-well-known', 'macros'] }
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+url = "2.5"
+time = { version = "0.3", features = ['serde-well-known', 'macros'] }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Basic usage requires a jira host, and a flavor of `jira::Credentials` for author
 
 Current support api support is limited to search and issue transitioning.
 
-```rust
+```rust,skeptic-template
 extern crate gouqi;
 
 use gouqi::{Credentials, Jira};

--- a/examples/comments.rs
+++ b/examples/comments.rs
@@ -1,0 +1,48 @@
+extern crate gouqi;
+
+use gouqi::{Credentials, Issues, Jira};
+use std::env;
+use tracing::error;
+
+fn main() {
+    // Initialize tracing global tracing subscriber
+    use tracing_subscriber::prelude::*;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        // Use RUST_LOG environment variable to set the tracing level
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        // Sets this to be the default, global collector for this application.
+        .init();
+
+    if let (Ok(host), Ok(user), Ok(password)) = (
+        env::var("JIRA_HOST"),
+        env::var("JIRA_USER"),
+        env::var("JIRA_PASS"),
+    ) {
+        let issue_id = env::args().nth(1).unwrap_or_else(|| "KAN-1".to_owned());
+
+        let jira =
+            Jira::new(host, Credentials::Basic(user, password)).expect("Error initializing Jira");
+
+        let issues = Issues::new(&jira);
+        let issue = issues.get(issue_id);
+
+        match issue {
+            Ok(issue) => {
+                if let Some(comments) = issue.comments() {
+                    for comment in comments.comments {
+                        println!(
+                            "{:?}: {:?}: {:?}",
+                            comment.author.unwrap().display_name,
+                            comment.created.unwrap(),
+                            comment.body,
+                        );
+                    }
+                }
+            }
+            e => error!("{:?}", e),
+        }
+    } else {
+        error!("Missing one or more environment variables JIRA_HOST, JIRA_USER, JIRA_PASS!");
+    }
+}

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -154,10 +154,9 @@ impl Issue {
             .unwrap_or_default()
     }
 
-    pub fn comment(&self) -> Vec<Comment> {
-        self.field::<Vec<Comment>>("comment")
+    pub fn comments(&self) -> Option<Comments> {
+        self.field::<Comments>("comment")
             .and_then(|value| value.ok())
-            .unwrap_or_default()
     }
 
     pub fn parent(&self) -> Option<Issue> {
@@ -203,6 +202,18 @@ pub struct Attachment {
     pub mime_type: String,
     pub content: String,
     pub thumbnail: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Comments {
+    pub comments: Vec<Comment>,
+    #[serde(rename = "self")]
+    pub self_link: String,
+    #[serde(rename = "maxResults")]
+    pub max_results: u32,
+    pub total: u32,
+    #[serde(rename = "startAt")]
+    pub start_at: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/tests/errors_test.rs
+++ b/tests/errors_test.rs
@@ -1,0 +1,19 @@
+extern crate gouqi;
+
+use gouqi::Error;
+#[test]
+fn test_error_display() {
+    let error = Error::Unauthorized;
+    assert_eq!(
+        format!("{}", error),
+        "Could not connect to Jira: Unauthorized\n"
+    );
+    let error = Error::MethodNotAllowed;
+    assert_eq!(
+        format!("{}", error),
+        "Jira request error: MethodNotAllowed\n"
+    );
+
+    let error = Error::NotFound;
+    assert_eq!(format!("{}", error), "Jira request error: NotFound\n");
+}

--- a/tests/rep_test.rs
+++ b/tests/rep_test.rs
@@ -13,7 +13,8 @@ fn issue_getters() {
         "id": "1234",
         "key": "MYPROJ-1234",
         "fields": {
-            "comment": [
+            "comment": {
+             "comments": [
                 {
                     "self": "http://www.example.com/jira/rest/api/2/issue/10010/comment/10000",
                     "id": "10000",
@@ -38,6 +39,11 @@ fn issue_getters() {
                     }
                 }
             ],
+            "self": "https://www.example.com/rest/api/2/issue/10000/comment",
+            "maxResults": 2,
+            "total": 2,
+            "startAt": 0
+            },
             "resolutiondate": "2018-07-11T16:56:12.000+0000",
             "created": "2018-07-11T10:56:12.000Z",
             "updated": "2018-07-11T12:56:12.000+00:00"
@@ -59,6 +65,12 @@ fn issue_getters() {
     assert_eq!(issue.resolution_date(), expected_resolution_date);
     assert_eq!(issue.created(), expected_created_date);
     assert_eq!(issue.updated(), expected_updated_date);
-    assert_ne!(issue.comment().len(), empty_comments.len());
-    assert_eq!(issue.comment()[0].created, expected_comment_updated_date);
+    assert_ne!(
+        issue.comments().unwrap().comments.len(),
+        empty_comments.len()
+    );
+    assert_eq!(
+        issue.comments().unwrap().comments[0].created,
+        expected_comment_updated_date
+    );
 }


### PR DESCRIPTION
Early versions of the Rest API directly added comment information into the output:

"comment": [ ]

This has been changed to provide additional meta-information and the comments moved one level deeper:

"comment": {
    "comments": [ ]
}

The change needs a version upgrade as the interfaces changes.

fixes #63