### PR TITLE
Update changelog to work with new API that moves it to a separate API…

### DIFF
--- a/examples/changelog.rs
+++ b/examples/changelog.rs
@@ -1,0 +1,55 @@
+extern crate gouqi;
+
+use gouqi::{Credentials, Issues, Jira};
+use std::env;
+use tracing::error;
+
+fn main() {
+    // Initialize tracing global tracing subscriber
+    use tracing_subscriber::prelude::*;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        // Use RUST_LOG environment variable to set the tracing level
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        // Sets this to be the default, global collector for this application.
+        .init();
+
+    if let (Ok(host), Ok(user), Ok(password)) = (
+        env::var("JIRA_HOST"),
+        env::var("JIRA_USER"),
+        env::var("JIRA_PASS"),
+    ) {
+        let issue_id = env::args().nth(1).unwrap_or_else(|| "KAN-1".to_owned());
+
+        let jira =
+            Jira::new(host, Credentials::Basic(user, password)).expect("Error initializing Jira");
+
+        let issues = Issues::new(&jira);
+        let issue = issues.get(issue_id);
+
+        match issue {
+            Ok(issue) => {
+                let histories = issues.changelog(issue.key).unwrap().histories;
+
+                for history in histories {
+                    let author = history.author.display_name;
+                    let created = history.created;
+                    let items = history.items;
+                    println!("{} \t {}\n ", author, created);
+
+                    for item in items {
+                        let field = item.field;
+                        let from = item.from_string.unwrap_or_else(|| "Null".to_string());
+                        let to = item.to_string.unwrap_or_else(|| "Null".to_string());
+                        println!("\"{}\" \t \"{}\" => \"{}\"\n", field, from, to);
+                    }
+                    println!()
+                }
+
+            }
+            e => error!("{:?}", e),
+        }
+    } else {
+        error!("Missing one or more environment variables JIRA_HOST, JIRA_USER, JIRA_PASS!");
+    }
+}

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use url::form_urlencoded;
 
 // Ours
-use crate::{Board, Comment, Issue, IssueType, Jira, Priority, Project, Result, SearchOptions};
+use crate::{Board, Changelog, Comment, Issue, IssueType, Jira, Priority, Project, Result, SearchOptions};
 
 /// Issue options
 #[derive(Debug)]
@@ -187,6 +187,18 @@ impl Issues {
             data,
         )
     }
+
+    pub fn changelog<K>(&self, key: K) -> Result<Changelog> 
+    where
+    K: Into<String>,
+    {
+        self.jira.get(
+            "api",
+            format!("/issue/{}/changelog", key.into()).as_ref(),
+        )
+    }
+
+
 }
 
 /// Provides an iterator over multiple pages of search results

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -24,7 +24,6 @@ pub struct Issue {
     pub key: String,
     pub id: String,
     pub fields: BTreeMap<String, ::serde_json::Value>,
-    pub changelog: Option<Changelog>,
 }
 
 impl Issue {
@@ -241,6 +240,7 @@ pub struct Visibility {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Changelog {
+    #[serde(rename = "values")]
     pub histories: Vec<History>,
 }
 


### PR DESCRIPTION
Update changelog to work with new API that moves it to a separate API call, and provide example.

https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/\#api-rest-api-3-issue-issueidorkey-changelog-get





