### PR TITLE
chore: release v0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gouqi"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["softprops <d.tangren@gmail.com>", "avrabe <ralf_beier@me.com>"]
 description = "Rust interface for Jira"
 documentation = "https://docs.rs/gouqi"


### PR DESCRIPTION
## Release v0.15.1

### 🐛 Bug Fixes
- **Critical**: Fixed AsyncIssueStream infinite loop when using V3 API pagination (#112)
- Resolved issue where async streams would repeatedly return the same page with V3 API

### 🧪 Testing
- Added comprehensive V3 pagination test suite with multi-page scenarios  
- Enhanced async test coverage with timeout guards to prevent infinite loops
- Added sync/async parity validation tests

### 📋 Technical Details  
- AsyncIssueStream now properly handles V3 nextPageToken pagination
- Added persistent future management to prevent state loss across poll cycles
- Maintained full backward compatibility with V2 startAt pagination

### 📦 Release Checklist
- [x] Bug fix implemented and tested
- [x] Comprehensive test coverage added
- [x] Version bumped to 0.15.1
- [x] Changelog updated in tag message
- [ ] Merge and publish to crates.io

This release resolves a critical bug that could cause infinite loops in user applications when using async streams with the Jira V3 API.

**Breaking Changes**: None - this is a bug fix release with full backward compatibility.