### PR TITLE
feat(worklogs): add ergonomic time helpers and fix JIRA date format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock
 .vscode
 coverage/cobertura.xml
 .claude/settings.local.json
+.env
 
 # Analysis documents
 *_AUDIT.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gouqi"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["softprops <d.tangren@gmail.com>", "avrabe <ralf_beier@me.com>"]
 description = "Rust interface for Jira"
 documentation = "https://docs.rs/gouqi"

--- a/examples/test_worklog_with_started.rs
+++ b/examples/test_worklog_with_started.rs
@@ -1,0 +1,115 @@
+//! Example demonstrating worklog creation with ergonomic time helpers
+//! This tests the fix for issue #123 and showcases new helper methods
+
+use gouqi::WorklogInput;
+use time::{OffsetDateTime, macros::datetime};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Testing worklog with ergonomic time helpers...\n");
+
+    // Example 1: Using time unit helpers
+    println!("=== Example 1: Creating worklogs with different time units ===");
+    let from_hours = WorklogInput::from_hours(2);
+    let from_minutes = WorklogInput::from_minutes(30);
+    let from_days = WorklogInput::from_days(1); // 8 hour workday
+    let from_weeks = WorklogInput::from_weeks(1); // 5 day workweek
+
+    println!(
+        "2 hours = {} seconds",
+        from_hours.time_spent_seconds.unwrap()
+    );
+    println!(
+        "30 minutes = {} seconds",
+        from_minutes.time_spent_seconds.unwrap()
+    );
+    println!(
+        "1 day = {} seconds (8h workday)",
+        from_days.time_spent_seconds.unwrap()
+    );
+    println!(
+        "1 week = {} seconds (5d workweek)",
+        from_weeks.time_spent_seconds.unwrap()
+    );
+
+    // Example 2: Using relative time helpers
+    println!("\n=== Example 2: Setting started time relative to now ===");
+
+    // These create worklogs with start times relative to now
+    WorklogInput::from_hours(2)
+        .started_hours_ago(3)
+        .with_comment("Started 3 hours ago");
+    println!("✓ Can create worklog that started 3 hours ago");
+
+    WorklogInput::from_hours(4)
+        .started_days_ago(2)
+        .with_comment("Started 2 days ago");
+    println!("✓ Can create worklog that started 2 days ago");
+
+    // Example 3: Using specific datetime
+    println!("\n=== Example 3: Setting specific start time ===");
+    let specific_time = datetime!(2024-01-15 09:00:00 UTC);
+    WorklogInput::from_hours(3)
+        .started_at(specific_time)
+        .with_comment("Started at specific time");
+    println!("✓ Worklog started at: {}", specific_time);
+
+    // Example 4: Complete workflow example with correct date formatting
+    println!("\n=== Example 4: Complete worklog with JIRA-compatible format ===");
+    let started = OffsetDateTime::from_unix_timestamp(1704096000)?;
+
+    let worklog = WorklogInput::from_hours(2)
+        .with_comment("Fixed critical bug - issue #123 fix validated")
+        .with_started(started);
+
+    // Serialize to see the format
+    let serialized = serde_json::to_string_pretty(&worklog)?;
+    println!("\nWorklog JSON (should have correct JIRA format):");
+    println!("{}", serialized);
+
+    // Verify the format
+    let serialized_compact = serde_json::to_string(&worklog)?;
+    assert!(
+        serialized_compact.contains("2024-01-01T08:00:00.000+0000"),
+        "Date format incorrect"
+    );
+    assert!(
+        !serialized_compact.contains("+002024"),
+        "Should not have year prefix"
+    );
+    assert!(
+        !serialized_compact.contains("Z\""),
+        "Should not use Z notation"
+    );
+
+    println!("\n✓ Date format validation passed!");
+    println!("✓ Format matches JIRA expectations: 2024-01-01T08:00:00.000+0000");
+
+    // Example 5: Practical real-world usage
+    println!("\n=== Example 5: Real-world usage patterns ===");
+
+    // Log work that happened yesterday
+    WorklogInput::from_hours(6)
+        .started_days_ago(1)
+        .with_comment("Implemented user authentication");
+    println!("✓ Created worklog for yesterday");
+
+    // Log work from this morning
+    WorklogInput::from_minutes(45)
+        .started_hours_ago(4)
+        .with_comment("Code review and bug fixes");
+    println!("✓ Created worklog from this morning");
+
+    // Log work for a specific date/time
+    WorklogInput::from_hours(3)
+        .started_at(datetime!(2024-01-10 14:00:00 UTC))
+        .with_comment("Backend API development");
+    println!("✓ Created worklog for specific date");
+
+    println!("\n=== Summary ===");
+    println!("✓ Issue #123 fixed - WorklogInput now uses correct JIRA date format");
+    println!("✓ Added ergonomic time helpers: from_hours, from_minutes, from_days, from_weeks");
+    println!("✓ Added relative time helpers: started_hours_ago, started_days_ago, etc.");
+    println!("✓ All datetime values are correctly serialized for JIRA API");
+
+    Ok(())
+}

--- a/src/sprints.rs
+++ b/src/sprints.rs
@@ -50,14 +50,14 @@ pub struct UpdateSprint {
         default,
         skip_serializing_if = "Option::is_none",
         rename = "startDate",
-        with = "time::serde::iso8601::option"
+        with = "crate::rep::jira_datetime"
     )]
     pub start_date: Option<OffsetDateTime>,
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         rename = "endDate",
-        with = "time::serde::iso8601::option"
+        with = "crate::rep::jira_datetime"
     )]
     pub end_date: Option<OffsetDateTime>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/sprints_test.rs
+++ b/tests/sprints_test.rs
@@ -85,3 +85,74 @@ fn deserialise_sprint_results() {
     assert!(sprint_results.is_last);
     assert_eq!(sprint_results.values.len(), 1);
 }
+
+#[test]
+fn test_update_sprint_date_serialization() {
+    use time::OffsetDateTime;
+
+    // Test UTC timezone - should produce format: "2024-01-01T09:00:00.000+0000"
+    let start = OffsetDateTime::from_unix_timestamp(1704096000).unwrap(); // 2024-01-01 08:00:00 UTC
+    let end = OffsetDateTime::from_unix_timestamp(1704182400).unwrap(); // 2024-01-02 08:00:00 UTC
+
+    let update = UpdateSprint {
+        name: Some("Sprint 1".to_string()),
+        start_date: Some(start),
+        end_date: Some(end),
+        state: Some("active".to_string()),
+    };
+
+    let serialized = serde_json::to_string(&update).unwrap();
+    println!("UpdateSprint serialized: {}", serialized);
+
+    // Verify the format matches JIRA expectations
+    assert!(serialized.contains("\"startDate\":\"2024-01-01T08:00:00.000+0000\""));
+    assert!(serialized.contains("\"endDate\":\"2024-01-02T08:00:00.000+0000\""));
+    assert!(!serialized.contains("+002024")); // Should not have year prefix
+    assert!(!serialized.contains("Z\"")); // Should not use Z notation
+    assert!(serialized.contains("\"name\":\"Sprint 1\""));
+    assert!(serialized.contains("\"state\":\"active\""));
+}
+
+#[test]
+fn test_update_sprint_date_with_timezone() {
+    use time::{OffsetDateTime, UtcOffset};
+
+    // Test with +10:00 timezone (Australian Eastern)
+    let utc_time = OffsetDateTime::from_unix_timestamp(1704096000).unwrap();
+    let aest_offset = UtcOffset::from_hms(10, 0, 0).unwrap();
+    let aest_time = utc_time.to_offset(aest_offset);
+
+    let update = UpdateSprint {
+        name: None,
+        start_date: Some(aest_time),
+        end_date: None,
+        state: None,
+    };
+
+    let serialized = serde_json::to_string(&update).unwrap();
+    println!("UpdateSprint with AEST: {}", serialized);
+
+    // Should include +1000 offset and proper date in that timezone
+    assert!(serialized.contains("+1000"));
+    assert!(serialized.contains("2024-01-01T18:00:00.000+1000"));
+}
+
+#[test]
+fn test_update_sprint_without_dates() {
+    // Test that omitting date fields works correctly
+    let update = UpdateSprint {
+        name: Some("Sprint 2".to_string()),
+        start_date: None,
+        end_date: None,
+        state: Some("future".to_string()),
+    };
+
+    let serialized = serde_json::to_string(&update).unwrap();
+    println!("UpdateSprint without dates: {}", serialized);
+
+    // Should not include date fields at all
+    assert!(!serialized.contains("\"startDate\""));
+    assert!(!serialized.contains("\"endDate\""));
+    assert!(serialized.contains("\"name\":\"Sprint 2\""));
+    assert!(serialized.contains("\"state\":\"future\""));
+}


### PR DESCRIPTION
## Summary

This PR adds ergonomic helper methods for creating worklogs and fixes the JIRA date format issue reported in #123.

### Changes

**Date Format Fix:**
- Fixed JIRA date format for `WorklogInput.started` and `UpdateSprint` date fields
- Created custom `jira_datetime` serializer that produces correct format: `2024-01-01T08:00:00.000+0000`
- Eliminates year prefix (+002024), uses milliseconds (not nanoseconds), and explicit timezone offset

**New Helper Methods:**

*Time Unit Constructors:*
- `WorklogInput::from_minutes(minutes)` - Convert minutes to worklog
- `WorklogInput::from_hours(hours)` - Convert hours to worklog
- `WorklogInput::from_days(days)` - Convert days (8h workday) to worklog
- `WorklogInput::from_weeks(weeks)` - Convert weeks (5d workweek) to worklog

*Relative Time Setters:*
- `started_hours_ago(hours)` - Set start time relative to now
- `started_minutes_ago(minutes)` - Set start time relative to now
- `started_days_ago(days)` - Set start time relative to now
- `started_weeks_ago(weeks)` - Set start time relative to now
- `started_at(datetime)` - Set specific start time

### Testing

- Added 13 new worklog tests covering time conversions and date serialization
- Added 3 new sprint tests for date handling
- All 27 worklog tests passing
- All 6 sprint tests passing
- New example `test_worklog_with_started.rs` demonstrating all features

### Version

- Bumped version to 0.18.0

Fixes #123