### PR TITLE
chore: release v0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gouqi"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["softprops <d.tangren@gmail.com>", "avrabe <ralf_beier@me.com>"]
 description = "Rust interface for Jira"
 documentation = "https://docs.rs/gouqi"


### PR DESCRIPTION
Version bump to 0.20.0 for release.

This PR updates the version in Cargo.toml after the v0.20.0 release has been created.

## Changes
- Bump version from 0.19.1 to 0.20.0

## Release
https://github.com/wunderfrucht/gouqi/releases/tag/v0.20.0